### PR TITLE
Fix loading images from urls

### DIFF
--- a/lib/pass.js
+++ b/lib/pass.js
@@ -238,7 +238,6 @@ Pass.prototype.pipe = function(output) {
   addFile("pass.json").end(passJson, "utf8");
 
   var expecting = 0;
-
   for (var key in self.images ){
     var filename = key.replace(/2x$/, "@2x") + ".png";
     var file = addFile(filename);


### PR DESCRIPTION
The problem: Using urls for the icon and logo images will fail. It will load at all of them but one. It finalises the manifest by calling doneWithImages() before the file has been loaded into the manifest.

The fix: listen for the file close event and then call doneWithImages if needs be. The sha hash generation takes time which caused the problem, this fixes that.

Also I added passkey.pem as this is needed to sign the pass now.
