### PR TITLE
Fixed loading of images via url

### DIFF
--- a/lib/pass.js
+++ b/lib/pass.js
@@ -238,14 +238,18 @@ Pass.prototype.pipe = function(output) {
   addFile("pass.json").end(passJson, "utf8");
 
   var expecting = 0;
-  for (var key in this.images) {
+  for (var key in self.images) {
     var filename = key.replace(/2x$/, "@2x") + ".png";
-    addImage(addFile(filename), this.images[key], function(error) {
+    var file = addFile(filename);
+    file.on('close', function(){
+      if (expecting === 0){
+        doneWithImages();
+      }
+    });
+    addImage(file, self.images[key], function(error) {
       --expecting;
       if (error)
         lastError = error;
-      if (expecting === 0)
-        doneWithImages();
     });
     ++expecting;
   }
@@ -292,7 +296,9 @@ function addImage(file, source, callback) {
       var protocol = /^https:/i.test(source) ? HTTPS : HTTP;
       protocol.get(source, function(response) {
         if (response.statusCode == 200) {
-          response.on("end", callback);
+          response.on("end", function(){
+            callback();
+          });
           response.pipe(file);
           response.resume();
         } else
@@ -347,6 +353,7 @@ function signManifest(template, manifest, callback) {
     "-sign", "-binary",
     "-signer",    Path.resolve(template.keysPath, identifier + ".pem"),
     "-certfile",  Path.resolve(template.keysPath, "wwdr.pem"),
+    "-inkey", Path.resolve(template.keysPath, "passkey.pem"),
     "-passin",    "pass:" + template.password
   ];
   var sign = execFile("openssl", args, { stdio: "pipe" }, function(error, stdout, stderr) {

--- a/lib/pass.js
+++ b/lib/pass.js
@@ -241,15 +241,13 @@ Pass.prototype.pipe = function(output) {
   for (var key in self.images) {
     var filename = key.replace(/2x$/, "@2x") + ".png";
     var file = addFile(filename);
-    file.on('close', function(){
-      if (expecting === 0){
-        doneWithImages();
-      }
-    });
     addImage(file, self.images[key], function(error) {
       --expecting;
       if (error)
         lastError = error;
+      if (expecting === 0){
+        doneWithImages();
+      }
     });
     ++expecting;
   }
@@ -296,7 +294,7 @@ function addImage(file, source, callback) {
       var protocol = /^https:/i.test(source) ? HTTPS : HTTP;
       protocol.get(source, function(response) {
         if (response.statusCode == 200) {
-          response.on("end", function(){
+          file.on("close", function(){
             callback();
           });
           response.pipe(file);

--- a/test/pass_test.js
+++ b/test/pass_test.js
@@ -180,13 +180,6 @@ describe("Pass", function() {
       });
     });
 
-    it("should contain a signature", function(done) {
-      execFile("signpass", ["-v", "/tmp/pass.pkpass"], function(error, stdout) {
-        assert(/\*\*\* SUCCEEDED \*\*\*/.test(stdout), stdout);
-        done();
-      });
-    });
-
     it("should contain the icon", function(done) {
       unzip("/tmp/pass.pkpass", "icon.png", function(error, buffer) {
         assert.equal(Crypto.createHash("sha1").update(buffer).digest("hex"),

--- a/test/pass_test.js
+++ b/test/pass_test.js
@@ -180,6 +180,13 @@ describe("Pass", function() {
       });
     });
 
+    it("should contain a signature", function(done) {
+      execFile("signpass", ["-v", "/tmp/pass.pkpass"], function(error, stdout) {
+        assert(/\*\*\* SUCCEEDED \*\*\*/.test(stdout), stdout);
+        done();
+      });
+    });
+
     it("should contain the icon", function(done) {
       unzip("/tmp/pass.pkpass", "icon.png", function(error, buffer) {
         assert.equal(Crypto.createHash("sha1").update(buffer).digest("hex"),


### PR DESCRIPTION
The problem: Using urls for the icon and logo images will fail. It will load at all of them but one. It finalises the manifest by calling doneWithImages() before the file has been loaded into the manifest.

The fix: listen for the file close event and then call doneWithImages if needs be. The sha hash generation takes time which caused the problem, this fixes that.

Also I added passkey.pem as this is needed to sign the pass now.
I also removed the signature check test as it will only ever pass on osx which is not ideal.

All tests pass.