### PR TITLE
Windows Fixes

### DIFF
--- a/lib/pass.js
+++ b/lib/pass.js
@@ -352,7 +352,7 @@ function signManifest(template, manifest, callback) {
   var sign = execFile("openssl", args, { stdio: "pipe" }, function(error, stdout, stderr) {
     var trimmedStderr = stderr.trim(); 
     // Windows outputs some unhelpful error messages, but still produces a valid signature
-    if (error || trimmedStderr != null && trimmedStderr != "Loading 'screen' into random state - done" && trimmedStderr != "Loading 'screen' into random state - done\nunable to write 'random state'") {
+    if (error || trimmedStderr != null && trimmedStderr != "Loading 'screen' into random state - done" && trimmedStderr != "Loading 'screen' into random state - done\r\nunable to write 'random state'") {
       callback(new Error(stderr));
     } else {
       var signature = stdout.split(/\n\n/)[3];

--- a/lib/pass.js
+++ b/lib/pass.js
@@ -350,7 +350,9 @@ function signManifest(template, manifest, callback) {
     "-passin",    "pass:" + template.password
   ];
   var sign = execFile("openssl", args, { stdio: "pipe" }, function(error, stdout, stderr) {
-    if (error || stderr.trim()) {
+    var trimmedStderr = stderr.trim(); 
+    // Windows outputs some unhelpful error messages, but still produces a valid signature
+    if (error || trimmedStderr != null && trimmedStderr != "Loading 'screen' into random state - done" && trimmedStderr != "Loading 'screen' into random state - done\nunable to write 'random state'") {
       callback(new Error(stderr));
     } else {
       var signature = stdout.split(/\n\n/)[3];


### PR DESCRIPTION
The windows version of openssl spits out a few status messages on stderr, this fix filters out those messages so the signature file is still produced