### PR TITLE
Fixes #34 and #35

### DIFF
--- a/lib/pass.js
+++ b/lib/pass.js
@@ -257,6 +257,9 @@ Pass.prototype.pipe = function(output) {
     } else {
       process.nextTick(function() {
         self.signZip(zip, manifest, function(error) {
+          if (error) {
+            return self.emit("error", error);
+          }
           zip.close();
           zip.on("end", function() {
             self.emit("end");

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "node-passbook": "./bin/node-passbook"
   },
   "dependencies": {
+    "async": "^0.9.0",
     "cli":    "0.6.5"
   },
   "devDependencies": {


### PR DESCRIPTION
1. Update package.json with async dependency.
2. Return error on `signZip` callback (not currently handled)