### PR TITLE
Add extra fields for companion app info

### DIFF
--- a/lib/pass.js
+++ b/lib/pass.js
@@ -15,7 +15,8 @@ var zlib              = require("zlib");
 
 
 // Top-level pass fields.
-var TOP_LEVEL           = [ "authenticationToken", "backgroundColor", "barcode", "description",
+var TOP_LEVEL           = [ "appLaunchURL", "associatedStoreIdentifiers", "authenticationToken",
+                            "backgroundColor", "barcode", "description",
                             "foregroundColor", "labelColor", "locations", "logoText",
                             "organizationName", "relevantDate", "serialNumber", 
                             "suppressStripShine", "webServiceURL"];

--- a/test/pass_test.js
+++ b/test/pass_test.js
@@ -107,6 +107,24 @@ describe("Pass", function() {
     });
   });
 
+  describe("with companion app keys", function() {
+
+    before(function() {
+      var fields = cloneExcept(this.fields, "not_used");
+      fields.appLaunchURL = "some_app_launch_url";
+      fields.associatedStoreIdentifiers = [123, 456];
+      this.pass = this.template.createPass(fields);
+    });
+
+    it("includes the app launch URL", function() {
+      assert.equal(this.pass.fields.appLaunchURL, "some_app_launch_url");
+    });
+
+    it("includes the associated store identifiers", function() {
+      assert.deepEqual(this.pass.fields.associatedStoreIdentifiers, [123, 456]);
+    });
+
+  });
 
   describe("generated", function() {
     before(function() {


### PR DESCRIPTION
Add in 2 extra fields to allow an app to be linked to the pass.

This resolves issue: https://github.com/assaf/node-passbook/issues/5
