### PR TITLE
Properly parse output of openssl on Windows

### DIFF
--- a/lib/pass.js
+++ b/lib/pass.js
@@ -365,7 +365,7 @@ function signManifest(template, manifest, callback) {
     if (error || (trimmedStderr && trimmedStderr.indexOf('- done') < 0)) {
       callback(new Error(stderr));
     } else {
-      var signature = stdout.split(/\r\n/)[3];
+      var signature = stdout.split(/(\r\n|\n\n)/)[3];
       callback(null, new Buffer(signature, "base64"));
     }
   });

--- a/lib/pass.js
+++ b/lib/pass.js
@@ -365,7 +365,7 @@ function signManifest(template, manifest, callback) {
     if (error || (trimmedStderr && trimmedStderr.indexOf('- done') < 0)) {
       callback(new Error(stderr));
     } else {
-      var signature = stdout.split(/\n\n/)[3];
+      var signature = stdout.split(/\r\n/)[3];
       callback(null, new Buffer(signature, "base64"));
     }
   });


### PR DESCRIPTION
Output text of openssl on Windows must be split by \r\n, not \n\n. So I fixed regex to have compatibility with both systems