### PR TITLE
Fixed SHA signature

### DIFF
--- a/lib/pass.js
+++ b/lib/pass.js
@@ -18,7 +18,7 @@ var zlib              = require("zlib");
 var TOP_LEVEL           = [ "appLaunchURL", "associatedStoreIdentifiers", "authenticationToken",
                             "backgroundColor", "barcode", "description",
                             "foregroundColor", "labelColor", "locations", "logoText",
-                            "organizationName", "relevantDate", "serialNumber", 
+                            "organizationName", "relevantDate", "serialNumber",
                             "suppressStripShine", "webServiceURL", "beacons"];
 // These top level fields are required for a valid pass.
 var REQUIRED_TOP_LEVEL  = [ "description", "organizationName", "passTypeIdentifier",
@@ -140,7 +140,7 @@ Fields.prototype.add = function(key, label, value, options) {
 // key      - Field key
 // label    - Field label (optional)
 // value    - Field value
-// Other field options (e.g. dateStyle) 
+// Other field options (e.g. dateStyle)
 Fields.prototype.get = function(key) {
   var fields = this.pass.structure[this.key];
   if (fields) {
@@ -367,7 +367,7 @@ function signManifest(template, manifest, callback) {
     if (error || (trimmedStderr && trimmedStderr.indexOf('- done') < 0)) {
       callback(new Error(stderr));
     } else {
-      var signature = stdout.split(/(\r\n|\n\n)/)[3];
+      var signature = stdout.split(/(\r\n|\n\n)/)[6];
       callback(null, Buffer.from(signature, "base64"));
     }
   });


### PR DESCRIPTION
The file was not being signed properly, now it is.
I couldn’t devise a test for this, because the error only occurs when I try to open the file. Before, the pkpass could not be opened, now, it does. Until this is merged in, I am using the npm package “pkpassbook” which is my fork of this repository containing the fix. Please note that I will not be actively maintaining the fork myself, since the fork’s current version suits my needs. 
Running macOS HighSierra 10.13.6.

Signed-off-by: Max Conradt <max@tilefive.com>