### PR TITLE
Removed bracket in regex to fixed empty signature issue

### DIFF
--- a/lib/pass.js
+++ b/lib/pass.js
@@ -367,7 +367,7 @@ function signManifest(template, manifest, callback) {
     if (error || (trimmedStderr && trimmedStderr.indexOf('- done') < 0)) {
       callback(new Error(stderr));
     } else {
-      var signature = stdout.split(/(\r\n|\n\n)/)[3];
+      var signature = stdout.split(/\r\n|\n\n/)[3];
       callback(null, Buffer.from(signature, "base64"));
     }
   });


### PR DESCRIPTION
The regular expression is capturing '\r\n' and '\n\n'. Therefore 3 more captured line breaks are in the result array of `stdout.split(/(\r\n\r\n|\n\n)/)` and the signature appears in position 6 instead of 3. 

I am having success by removing the bracket in the regular expression.
`var signature = stdout.split(/\r\n|\n\n/)[3];`